### PR TITLE
fix: drop handon-dev-postgres stop patch handling

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -260,11 +260,10 @@ jobs:
 
           # handon-dev の停止パッチをコメントアウト
           # (この PR をマージすると Flux が handon-dev を起動して新バージョンの動作確認ができる。
-          #  検証完了後は別 PR でコメントアウトを戻して再停止する。)
+          #  検証完了後は別 PR でコメントアウトを戻して再停止する。
+          #  注: handon-dev-postgres は常時起動運用のため Deployment 側の停止パッチのみ操作する。)
           STOP_PATCH_COMMENTED=false
           if grep -qE '^  # ▼▼▼ handon-dev 停止パッチ' clusters/production/apps.yaml; then
-            sed -i '/# ▼▼▼ handon-dev-postgres 停止パッチ/,/# ▲▲▲ handon-dev-postgres 停止パッチ ▲▲▲/ s/^/# /' \
-              clusters/production/apps.yaml
             sed -i '/# ▼▼▼ handon-dev 停止パッチ/,/# ▲▲▲ handon-dev 停止パッチ ▲▲▲/ s/^/# /' \
               clusters/production/apps.yaml
             STOP_PATCH_COMMENTED=true


### PR DESCRIPTION
## Summary
- handon-dev-postgres is now always-on; the postgres-side stop patch has been removed from clusters/production/apps.yaml in the k8sg1 repo
- This workflow no longer needs to comment out the postgres-side patch when generating an upstream-update PR — only the Deployment-side handon-dev stop patch is operated

## Background
CNPG 1.25.1 declarative hibernation caused a Pod delete → recreate loop on handon-dev/postgres. We switched handon-dev-postgres to always-on in highemerly/k8sg1; this workflow needs to match.

## Test plan
- [ ] Next upstream-update PR auto-generated by this workflow only comments out the Deployment-side handon-dev stop patch
- [ ] Generated PR still triggers Flux to start handon-dev (Mastodon side) for verification

Companion change: highemerly/k8sg1 (always-on handon-dev-postgres)